### PR TITLE
Replace property values with `created_by`/`creation_date` clauses 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,11 @@ $(ONT).obo: $(ONT).owl
 #	$(ROBOT) convert -i $< -f obo -o $(ONT).obo.tmp && grep -v '^owl-axioms:' $(ONT).obo.tmp > $@ && rm $(ONT).obo.tmp
 
 reasoner-report.txt: plant-ontology.obo
-	owltools $(CAT) $< --run-reasoner -r elk -u > $@.tmp && egrep '(INFERENCE|UNSAT)' $@.tmp > $@
+	$(OWLTOOLS) $(CAT) $< --run-reasoner -r elk -u > $@.tmp && egrep '(INFERENCE|UNSAT)' $@.tmp > $@
 
 # TODO: switch to using robot
 subsets/po-basic.obo: po.obo
-	owltools $(CAT) $< --remove-imports-declarations --make-subset-by-properties -f BFO:0000050 // --set-ontology-id $(OBO)/po/subsets/po-basic.owl -o -f obo $@
+	$(OWLTOOLS) $(CAT) $< --remove-imports-declarations --make-subset-by-properties -f BFO:0000050 // --set-ontology-id $(OBO)/po/subsets/po-basic.owl -o -f obo $@
 
 # ----------------------------------------
 # Imports

--- a/plant-ontology.obo
+++ b/plant-ontology.obo
@@ -22218,8 +22218,8 @@ synonym: "branch tip (exact)" EXACT []
 xref: PO_GIT:XYZ
 is_a: PO:0000037 ! shoot axis apex
 relationship: part_of PO:0025073 ! branch
-property_value: http://purl.org/dc/elements/1.1/date 2018-02-15T17:24:36Z xsd:dateTime
 created_by: Laurel_Cooper
+creation_date: 2018-02-15T17:24:36Z
 
 [Term]
 id: PO:0028005
@@ -24205,8 +24205,8 @@ synonym: "heterothetic double capitulum (narrow)" NARROW []
 synonym: "homothetic compound capitulum (narrow)" NARROW []
 synonym: "homothetic double capitulum (narrow)" NARROW []
 is_a: PO:0009049 ! inflorescence
-property_value: http://purl.org/dc/elements/1.1/creator NYBG:Brandon_Sinn xsd:string
-property_value: http://purl.org/dc/elements/1.1/date 2017-04-20T12:58:48Z xsd:dateTime
+created_by: NYBG:Brandon_Sinn
+creation_date: 2017-04-20T12:58:48Z
 
 [Term]
 id: PO:0030123


### PR DESCRIPTION
Hi Planteome people !

This PR uses the `created_by` and `creation_date` OBO clauses where applicable instead of current property values in the developer's version of the PO. This also has the effect to make the `plant-ontology.obo` as well as the generated `po.obo` compliant with the new [OBO 1.4 Syntax](http://owlcollab.github.io/oboformat/doc/obo-syntax.html) where all property values need to be quote-enclosed (since there is none remaining).

(cc @cmungall).