### PR TITLE
remove "nothing subclass of nothing" tautology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ release: all
 	echo "build successful. Now commit and push the derived files and make a release here: "
 
 $(ONT).owl: $(SRC)
-	$(ROBOT)  reason -x true -i $< -r ELK relax reduce -r ELK annotate -V $(BASE)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
+	$(ROBOT)  reason -x true -t true -i $< -r ELK relax reduce -r ELK annotate -V $(BASE)/releases/`date +%Y-%m-%d`/$(ONT).owl -o $@
 $(ONT).obo: $(ONT).owl
 	$(OWLTOOLS) $(CAT) $< -o -f obo --no-check $(ONT).obo.tmp && grep -v '^owl-axioms:' $(ONT).obo.tmp > $@ && rm $(ONT).obo.tmp
 #	$(ROBOT) convert -i $< -f obo -o $(ONT).obo.tmp && grep -v '^owl-axioms:' $(ONT).obo.tmp > $@ && rm $(ONT).obo.tmp

--- a/po.obo
+++ b/po.obo
@@ -1,5 +1,5 @@
 format-version: 1.2
-data-version: releases/2020-08-20
+data-version: releases/2021-08-13
 saved-by: cooperl
 subsetdef: Angiosperm "Term for angiosperms"
 subsetdef: Arabidopsis "Term used for Arabidopsis"
@@ -195,7 +195,6 @@ comment: Cultured somatic plant embryos are commonly induced after the formation
 synonym: "cultured somatic embryo (broad)" BROAD []
 synonym: "embri&#243n som&#225tico cultivado (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "培養植物体細胞不定胚 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0000010 ! cultured plant embryo
 is_a: PO:0025302 ! somatic plant embryo
 relationship: develops_from PO:0006091 ! embryogenic callus
@@ -210,7 +209,6 @@ synonym: "gancho apical (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gan
 synonym: "hypocotyl hook (related)" RELATED []
 synonym: "頂端かぎ状屈曲構造 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:70
-is_a: BFO:0000004
 is_a: PO:0025001 ! cardinal organ part
 relationship: develops_from PO:0020100 ! hypocotyl
 relationship: part_of PO:0006341 ! primary shoot system
@@ -340,7 +338,6 @@ synonym: "cut&#237cula (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gand
 synonym: "cuticle (broad)" BROAD []
 synonym: "植物クチクラ (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:416
-is_a: BFO:0000004
 is_a: PO:0025161 ! portion of plant substance
 relationship: adjacent_to PO:0005679 ! epidermis
 
@@ -461,7 +458,6 @@ subset: reference
 synonym: "t&#233trada de las microsporas (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "小胞子の四分子   小胞子四分子 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:236
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0020047 ! microsporocyte
 relationship: has_part PO:0020048 ! microspore
@@ -490,7 +486,6 @@ synonym: "sistema vascular (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_
 synonym: "vasculature (exact)" EXACT [FNA:caf918bf-f4c4-423c-8008-87c96e5399a0]
 synonym: "維管束系 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:50
-is_a: BFO:0000002
 is_a: PO:0009015 ! portion of vascular tissue
 disjoint_from: PO:0009002 ! plant cell
 disjoint_from: PO:0009008 ! plant organ
@@ -769,7 +764,6 @@ synonym: "adventitious bud (narrow)" NARROW [FNA:0eed275a-5dae-414a-bf36-81a08e6
 synonym: "yema (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "芽 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:124
-is_a: BFO:0000002
 is_a: PO:0009006 ! shoot system
 relationship: participates_in PO:0025528 ! bud development stage
 
@@ -948,7 +942,6 @@ synonym: "c&#233lula acompa&#241iante (Spanish, exact)" EXACT Spanish [POC:Maria
 synonym: "minor vein companion cell (exact)" EXACT []
 synonym: "伴細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:442
-is_a: BFO:0000004
 is_a: PO:0000074 ! parenchyma cell
 relationship: adjacent_to PO:0000289 ! sieve tube element
 relationship: part_of PO:0005417 ! phloem
@@ -1070,7 +1063,6 @@ synonym: "sperm cell (broad)" BROAD []
 synonym: "sperm nucleus (related)" RELATED []
 synonym: "植物精子細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:141
-is_a: BFO:0000004
 is_a: PO:0025006 ! plant gamete
 relationship: develops_from PO:0025525 ! spermatogenous cell
 
@@ -1099,7 +1091,6 @@ synonym: "cell located at the base of the trichome (related)" RELATED []
 synonym: "trichome support cell (related)" RELATED []
 synonym: "ソケット細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:8
-is_a: BFO:0000004
 is_a: PO:0025165 ! shoot epidermal cell
 disjoint_from: PO:0000332 ! epidermal pavement cell
 relationship: develops_from PO:0000349 ! epidermal initial cell
@@ -1331,7 +1322,6 @@ subset: CL
 subset: TraitNet
 synonym: "c&#233lula del pelo de la ra&#237z (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "根毛細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025164 ! root epidermal cell
 relationship: develops_from PO:0000262 ! trichoblast
 
@@ -1359,7 +1349,6 @@ subset: CL
 synonym: "hair cell (related)" RELATED []
 synonym: "tricoblasto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "根毛形成細胞、トリコブラスト (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025164 ! root epidermal cell
 relationship: develops_from PO:0000349 ! epidermal initial cell
 
@@ -1374,7 +1363,6 @@ synonym: "atrichoblast (exact)" EXACT []
 synonym: "atricoblasto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "non-hair cell (broad)" BROAD []
 synonym: "非毛根形成細胞、アトリコブラスト (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025164 ! root epidermal cell
 relationship: develops_from PO:0000349 ! epidermal initial cell
 
@@ -1453,7 +1441,6 @@ synonym: "squamule (narrow)" NARROW [FNA:f18da584-2b0b-4b03-a614-40140a1cb89e]
 synonym: "tricoma (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "毛茸、糸状体、毛 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:207
-is_a: BFO:0000004
 is_a: PO:0009011 ! plant structure
 relationship: develops_from PO:0000349 ! epidermal initial cell
 relationship: part_of PO:0005679 ! epidermis
@@ -1529,7 +1516,6 @@ subset: TraitNet
 synonym: "c&#233lula guardiana (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "occlusive cell (exact)" EXACT [PMID:16845829]
 synonym: "孔辺細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025165 ! shoot epidermal cell
 disjoint_from: PO:0000332 ! epidermal pavement cell
 relationship: develops_from PO:0000351 ! guard mother cell
@@ -1585,7 +1571,6 @@ subset: CL
 synonym: "c&#233lula del pavimento epidermal (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "表皮被蓋細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:256
-is_a: BFO:0000004
 is_a: PO:0025165 ! shoot epidermal cell
 disjoint_from: PO:0008030 ! trichome cell
 relationship: develops_from PO:0000349 ! epidermal initial cell
@@ -1612,7 +1597,6 @@ def: "A shoot epidermal cell that divides to produce the guard cells." [ISBN:047
 subset: CL
 synonym: "c&#233lula madre de la c&#233lula guardiana (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "孔辺母細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025165 ! shoot epidermal cell
 relationship: develops_from PO:0000062 ! stomatal initial cell
 
@@ -1694,7 +1678,6 @@ synonym: "cigoto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "zygote (broad)" BROAD []
 synonym: "植物接合子、接合体 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:417
-is_a: BFO:0000002
 is_a: PO:0025606 ! native plant cell
 relationship: participates_in PO:0001097 ! plant zygote stage
 
@@ -1915,7 +1898,6 @@ comment: The vascular leaf primordium (PO:0000017) develops from the vascular le
 synonym: "leaf stage P1 (related)" RELATED [GRO:0007164]
 synonym: "P1 stage (related)" RELATED []
 xref: OBO-SF2_PO:561
-is_a: BFO:0000003
 is_a: PO:0001051 ! vascular leaf initiation stage
 relationship: preceded_by PO:0001003 ! vascular leaf anlagen formation stage
 
@@ -2060,7 +2042,6 @@ synonym: "1.01-dry seed in Triticeae (related)" RELATED [GRO:0007052]
 synonym: "BBCH growth stage 00 (related)" RELATED [ISBN:3826331524]
 synonym: "dry seed in Arabidopsis (related)" RELATED [TAIR:0000213]
 xref: PO_GIT:568
-is_a: BFO:0000003
 is_a: PO:0001170 ! seed development stage
 relationship: preceded_by PO:0007632 ! seed maturation stage
 
@@ -2099,7 +2080,6 @@ namespace: plant_structure_development_stage
 def: "A phyllome development stage (PO:0025579) that has as a primary participant a lemma (PO:0009037)." [Gramene:Anuradha_Pujar, POC:Felipe_Zapata, POC:Laura_Moore]
 synonym: "spikelet stage SP3 (related)" RELATED [GRO:0007204]
 xref: PO_GIT:548
-is_a: BFO:0000003
 is_a: PO:0025579 ! phyllome development stage
 relationship: part_of PO:0007600 ! floral organ differentiation stage
 
@@ -2110,7 +2090,6 @@ namespace: plant_structure_development_stage
 def: "A phyllome development stage (PO:0025579) that has as a primary participant a palea (PO:0009038)." [Gramene:Anuradha_Pujar, POC:Felipe_Zapata, POC:Laura_Moore]
 synonym: "spikelet stage SP4 (related)" RELATED [GRO:0007207]
 xref: PO_GIT:548
-is_a: BFO:0000003
 is_a: PO:0025579 ! phyllome development stage
 relationship: part_of PO:0007600 ! floral organ differentiation stage
 
@@ -2121,7 +2100,6 @@ namespace: plant_structure_development_stage
 def: "A phyllome development stage (PO:0025579) that has as a primary participant a lodicule (PO:0009036)." [Gramene:Anuradha_Pujar, POC:Felipe_Zapata, POC:Laura_Moore]
 synonym: "spikelet stage SP5 (related)" RELATED [GRO:0007203]
 xref: PO_GIT:548
-is_a: BFO:0000003
 is_a: PO:0025579 ! phyllome development stage
 relationship: part_of PO:0007600 ! floral organ differentiation stage
 
@@ -2154,7 +2132,6 @@ def: "A vascular leaf development stage (PO:0025570) during which vascular leaf 
 comment: During this stage leaf shaping (GO:0010358) occurs which is defined as the developmental process that pertains to the organization of a leaf in three-dimensional space once the structure has initially formed.
 synonym: "leaf expansion stage in Arabidopsis (related)" RELATED []
 xref: PO_GIT:557
-is_a: BFO:0000003
 is_a: PO:0025570 ! vascular leaf development stage
 relationship: preceded_by PO:0025574 ! vascular leaf differentiation stage
 
@@ -2166,7 +2143,6 @@ def: "A vascular leaf development stage (PO:0025570) that begins when the vascul
 synonym: "fully expanded leaf stage in Arabidopsis (related)" RELATED []
 synonym: "leaf stage PX (related)" RELATED [GRO:0007167]
 xref: PO_GIT:558
-is_a: BFO:0000003
 is_a: PO:0025570 ! vascular leaf development stage
 relationship: preceded_by PO:0001052 ! vascular leaf expansion stage
 
@@ -2177,7 +2153,6 @@ namespace: plant_structure_development_stage
 def: "A vascular leaf development stage (PO:0025570) that begins with the formation of a abscission zone at the base of a vascular leaf (PO:0009025) and ends with leaf separation and death." [POC:Brian_Atkinson, POC:Laurel_Cooper, TAIR_curator:Tanya_Berardini]
 synonym: "leaf senescence stage in Arabidopsis (related)" RELATED []
 xref: PO_GIT:559
-is_a: BFO:0000003
 is_a: PO:0025570 ! vascular leaf development stage
 relationship: preceded_by PO:0001053 ! vascular leaf post-expansion stage
 
@@ -2478,7 +2453,6 @@ synonym: "c&#233lula basal (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_
 synonym: "embryonic basal cell (exact)" EXACT []
 synonym: "胚基底細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:281
-is_a: BFO:0000004
 is_a: PO:0025028 ! embryo plant cell
 relationship: develops_from PO:0000423 ! plant zygote
 
@@ -2679,7 +2653,6 @@ synonym: "n&#243dulo de la ra&#237z (Spanish, exact)" EXACT Spanish [POC:Maria_A
 synonym: "nodule (broad)" BROAD [FNA:b62e2f23-dffc-474a-a7bd-f919ea99b51c]
 synonym: "根粒 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:235
-is_a: BFO:0000004
 is_a: PO:0025001 ! cardinal organ part
 relationship: develops_from PO:0025194 ! root nodule meristem
 relationship: part_of PO:0009005 ! root
@@ -2919,7 +2892,6 @@ name: developing seed stage
 namespace: plant_structure_development_stage
 def: "Stage of seed development characterized by seed growth and differentiation." [TAIR_curator:Katica_Ilic]
 xref: PO_GIT:568
-is_a: BFO:0000003
 is_a: PO:0001170 ! seed development stage
 relationship: preceded_by PO:0007633 ! endosperm development stage
 
@@ -3059,7 +3031,6 @@ subset: TraitNet
 synonym: "corteza (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "portion of bark tissue (exact)" EXACT []
 synonym: "樹皮 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0005043 ! secondary phloem
 
@@ -3159,7 +3130,6 @@ synonym: "axial wood parenchyma cell (exact)" EXACT []
 synonym: "c&#233lula parenquim&#225tica axial de la madera (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "軸方向二次木部柔組織細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:456
-is_a: BFO:0000004
 is_a: PO:0004525 ! secondary xylem parenchyma cell
 intersection_of: PO:0004525 ! secondary xylem parenchyma cell
 intersection_of: part_of PO:0004533 ! axial secondary xylem parenchyma
@@ -3176,7 +3146,6 @@ synonym: "c&#233lula parenquim&#225tica de rayo de la madera (Spanish, exact)" E
 synonym: "ray wood parenchyma cell (exact)" EXACT []
 synonym: "放射状二次木部柔組織細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:456
-is_a: BFO:0000004
 is_a: PO:0004525 ! secondary xylem parenchyma cell
 intersection_of: PO:0004525 ! secondary xylem parenchyma cell
 intersection_of: part_of PO:0004534 ! ray secondary xylem parenchyma
@@ -3285,7 +3254,6 @@ subset: Tomato
 synonym: "placenta del fruto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "果実の胎座 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:144
-is_a: BFO:0000004
 is_a: PO:0020001 ! plant ovary placenta
 relationship: develops_from PO:0025078 ! placenta
 relationship: part_of PO:0009001 ! fruit
@@ -3301,7 +3269,6 @@ synonym: "pedicelo del fruto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandr
 synonym: "果柄 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:487
 xref: PO_GIT:49
-is_a: BFO:0000004
 is_a: PO:0030114 ! fruit pedicel
 relationship: develops_from PO:0009052 ! inflorescence flower pedicel
 relationship: part_of PO:0006342 ! infructescence
@@ -3386,7 +3353,6 @@ synonym: "tub&#233rculo (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gan
 synonym: "tuber branch (exact)" EXACT []
 synonym: "シュート軸塊茎 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:127
-is_a: BFO:0000004
 is_a: PO:0025029 ! shoot axis
 is_a: PO:0025522 ! tuber
 relationship: develops_from PO:0025073 ! branch
@@ -4124,7 +4090,6 @@ synonym: "primordio de ra&#237z (Spanish, exact)" EXACT Spanish [POC:Maria_Aleja
 synonym: "root primordia (exact, plural)" EXACT []
 synonym: "根原基（可視的）  (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:467
-is_a: BFO:0000004
 is_a: PO:0025127 ! primordium
 relationship: develops_from PO:0025433 ! root anlagen
 
@@ -4184,7 +4149,6 @@ synonym: "meristematic cap (related)" RELATED []
 synonym: "PTM (exact)" EXACT []
 synonym: "一次 肥厚（膜）分裂組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:437
-is_a: BFO:0000004
 is_a: PO:0006344 ! shoot lateral meristem
 relationship: develops_from PO:0000225 ! peripheral zone
 relationship: part_of PO:0009047 ! stem
@@ -4676,7 +4640,6 @@ synonym: "multiseriate epidermis (related)" RELATED []
 synonym: "portion of epidermal tissue (exact)" EXACT []
 synonym: "表皮 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:109
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0006210 ! protoderm
 
@@ -4772,7 +4735,6 @@ synonym: "portion of primary xylem tissue (exact)" EXACT []
 synonym: "xilema primario (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "一次木部 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:434
-is_a: BFO:0000004
 is_a: PO:0005352 ! xylem
 relationship: develops_from PO:0025275 ! procambium
 
@@ -4788,7 +4750,6 @@ synonym: "pl&#250mula de Poaceae (Spanish, exact)" EXACT Spanish [POC:Maria_Alej
 synonym: "Poaceae hull (exact)" EXACT []
 synonym: "イネ科植物 籾殻、外皮 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:239
-is_a: BFO:0000004
 is_a: PO:0025023 ! collective phyllome structure
 relationship: develops_from PO:0009037 ! lemma
 relationship: develops_from PO:0009038 ! palea
@@ -4803,7 +4764,6 @@ subset: reference
 subset: TraitNet
 synonym: "filoma (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "フィロム、葉(的）器官 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0009008 ! plant organ
 relationship: develops_from PO:0025128 ! phyllome primordium
 relationship: part_of PO:0009006 ! shoot system
@@ -4932,7 +4892,6 @@ subset: CL
 synonym: "c&#233lula primaria parietal (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "一次側膜細胞、壁細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:359
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0006014 ! male archesporial cell
 relationship: part_of PO:0006006 ! anther wall primary parietal cell layer
@@ -5560,7 +5519,6 @@ synonym: "floema primario (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_G
 synonym: "portion of primary phloem tissue (exact)" EXACT []
 synonym: "一次師部 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: OBO_SF3_PO:433
-is_a: BFO:0000004
 is_a: PO:0005417 ! phloem
 relationship: develops_from PO:0025275 ! procambium
 
@@ -5708,7 +5666,6 @@ subset: CL
 synonym: "c&#233lula espor&#243gena primaria (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "一次胞子形成細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:328
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0006014 ! male archesporial cell
 
@@ -5819,7 +5776,6 @@ synonym: "spore mother cell (exact)" EXACT []
 synonym: "胞子母細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: GO:0007126
 xref: PO_GIT:361
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0030056 ! archesporial cell
 relationship: part_of PO:0025094 ! sporangium
@@ -6132,7 +6088,6 @@ subset: Maize
 synonym: "penacho (borla) de la espiguilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "雄穂（花）の小穂 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:537
-is_a: BFO:0000004
 is_a: PO:0009051 ! spikelet
 relationship: develops_from PO:0006358 ! tassel spikelet pair meristem
 relationship: part_of PO:0020126 ! tassel inflorescence
@@ -6364,7 +6319,6 @@ namespace: plant_anatomy
 def: "A cardinal part of multi-tissue plant structure (PO:0025498) that is a ridge on a seed (PO:0009010) that develops from a raphe (PO:0020027)." [ISBN:0471245208, POC:curators]
 synonym: "rafe de la semilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "種子背線、縫線 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025498 ! cardinal part of multi-tissue plant structure
 relationship: develops_from PO:0020027 ! raphe
 relationship: part_of PO:0009010 ! seed
@@ -6376,7 +6330,6 @@ namespace: plant_anatomy
 def: "A cardinal part of multi-tissue plant structure (PO:0025498) that is attached to a seed (PO:0009010) and is the remnants of a funicle (PO:0020006)." [POC:curators]
 synonym: "fun&#237culo de la semilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "種子種柄 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025498 ! cardinal part of multi-tissue plant structure
 relationship: develops_from PO:0020006 ! funicle
 relationship: part_of PO:0009010 ! seed
@@ -6389,7 +6342,6 @@ def: "A remnant of the ovular chalaza that is part of the seed." [POC:curators]
 synonym: "calaza de la semilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "portion of seed chalaza (exact)" EXACT []
 synonym: "種子 カラザ (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0020026 ! chalaza
 relationship: part_of PO:0009010 ! seed
@@ -6402,7 +6354,6 @@ def: "A plant anatomical space that is enclosed by and forms an opening in a see
 subset: TraitNet
 synonym: "micr&#243pila de la semilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "種子珠孔 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025117 ! plant anatomical space
 relationship: develops_from PO:0020025 ! plant ovule micropyle
 relationship: part_of PO:0009088 ! seed coat
@@ -6415,7 +6366,6 @@ def: "An outgrowth of the seed funicle, that forms a bridge between the seed mic
 synonym: "obturador de la semilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "portion of seed obturator tissue (exact)" EXACT []
 synonym: "種子閉塞組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0020029 ! obturator
 relationship: part_of PO:0006332 ! seed funicle
@@ -6514,7 +6464,6 @@ synonym: "sistema axilar del epiblasto (epiblastema) (Spanish, exact)" EXACT Spa
 synonym: "腋苗条系 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:262
 xref: PO_GIT:518
-is_a: BFO:0000004
 is_a: PO:0004545 ! shoot-borne shoot system
 relationship: develops_from PO:0004709 ! axillary bud
 
@@ -7279,7 +7228,6 @@ synonym: "radicle emergence in Arabidopsis (related)" RELATED [TAIR:T0000395]
 synonym: "radicle emergence in Solanaceae (related)" RELATED [SGN:0000006]
 synonym: "Zadok scale-5 (related)" RELATED [GRO:0007055]
 xref: PO_GIT:386
-is_a: BFO:0000003
 is_a: PO:0007520 ! root development stage
 relationship: part_of PO:0007057 ! seed germination stage
 
@@ -7601,7 +7549,6 @@ synonym: "Solanaceae whole plant growth stages (SGN:0000001) (related)" RELATED 
 synonym: "sorghum growth stage (GRO:0007124) (related)" RELATED []
 synonym: "wheat, barley and oat growth stage (GRO:0007156) (related)" RELATED []
 xref: PO_GIT:390
-is_a: BFO:0000003
 is_a: PO:0009012 ! plant structure development stage
 relationship: has_participant PO:0000003 ! whole plant
 
@@ -9738,7 +9685,6 @@ def: "Stage during which the seed storage products (storage proteins, lipids and
 synonym: "embryo stage EM10 (related)" RELATED [GRO:0007177]
 synonym: "seed maturation in Arabidopsis (related)" RELATED []
 xref: PO_GIT:568
-is_a: BFO:0000003
 is_a: PO:0001170 ! seed development stage
 relationship: preceded_by PO:0004506 ! developing seed stage
 
@@ -9748,7 +9694,6 @@ name: endosperm development stage
 namespace: plant_structure_development_stage
 def: "Stages of development of the endosperm." [TAIR_curator:Katica_Ilic]
 xref: PO_GIT:568
-is_a: BFO:0000003
 is_a: PO:0001170 ! seed development stage
 relationship: preceded_by PO:0004505 ! fertilized ovule stage
 
@@ -10121,7 +10066,6 @@ subset: CL
 synonym: "c&#233lula del tricoma (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "毛（毛茸、糸状体）細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:207
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0004013 ! epidermal cell
 relationship: part_of PO:0025162 ! multicellular trichome
@@ -10391,7 +10335,6 @@ synonym: "propagule  (broad)" BROAD []
 synonym: "syncarp (narrow)" NARROW [FNA:67fa41ae-b735-4d89-b5db-7631b873ef7a]
 synonym: "果実 (exact, Japanese)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:76
-is_a: BFO:0000004
 is_a: PO:0025496 ! multi-tissue plant structure
 relationship: develops_from PO:0009062 ! gynoecium
 
@@ -10469,7 +10412,6 @@ synonym: "radices (exact, plural)" EXACT [FNA:3c46e84c-23e4-416b-91cd-2f7c42e4b1
 synonym: "radix (exact)" EXACT [FNA:e6315684-fc99-4976-b39d-b356c4b7e7fd]
 synonym: "根 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:578
-is_a: BFO:0000004
 is_a: PO:0025004 ! plant axis
 relationship: develops_from PO:0005029 ! root primordium
 relationship: part_of PO:0025025 ! root system
@@ -10561,7 +10503,6 @@ synonym: "pyrene (narrow)" NARROW [FNA:f5c50e73-61e3-48ec-b918-6f85b3f40738]
 synonym: "semilla (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "種子 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:405
-is_a: BFO:0000004
 is_a: PO:0025496 ! multi-tissue plant structure
 relationship: develops_from PO:0020003 ! plant ovule
 relationship: has_part PO:0009009 ! plant embryo
@@ -10590,6 +10531,7 @@ synonym: "Arabidopsis growth (related)" RELATED [TAIR:0000205]
 synonym: "etapa de desarrollo de estructura vegetal (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "plant growth and development stage (exact)" EXACT []
 xref: PO_GIT:185
+is_a: BFO:0000015
 
 [Term]
 id: PO:0009013
@@ -11133,7 +11075,6 @@ synonym: "perfect flower (narrow)" NARROW []
 synonym: "花 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:160
 xref: PO_GIT:259
-is_a: BFO:0000004
 is_a: PO:0025082 ! reproductive shoot system
 relationship: develops_from PO:0000229 ! flower meristem
 
@@ -11412,7 +11353,6 @@ synonym: "Zea androecium (narrow)" NARROW []
 synonym: "雄蕊群 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:71
 xref: PO_GIT:98
-is_a: BFO:0000004
 is_a: PO:0025023 ! collective phyllome structure
 relationship: develops_from PO:0025478 ! androecium primordium
 relationship: part_of PO:0009046 ! flower
@@ -11460,7 +11400,6 @@ synonym: "雌蕊群 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:470
 xref: PO_GIT:71
 xref: PO_GIT:98
-is_a: BFO:0000004
 is_a: PO:0025023 ! collective phyllome structure
 relationship: develops_from PO:0000019 ! gynoecium primordium
 relationship: part_of PO:0009046 ! flower
@@ -11530,7 +11469,6 @@ synonym: "Zea anther (narrow)" NARROW []
 synonym: "半葯,花粉のう (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:297
 xref: PO_GIT:70
-is_a: BFO:0000004
 is_a: PO:0025007 ! collective plant organ structure
 relationship: develops_from PO:0006089 ! anther primordium
 relationship: has_part PO:0025277 ! pollen sac
@@ -11898,7 +11836,6 @@ subset: TraitNet
 synonym: "arilo (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "仮種皮 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:242
-is_a: BFO:0000004
 is_a: PO:0019022 ! arilloid
 relationship: develops_from PO:0020006 ! funicle
 
@@ -11934,7 +11871,6 @@ subset: Maize
 synonym: "ramificaci&#243n lateral larga del penacho (borla) (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "second order tassel branch (related)" RELATED []
 synonym: "雄穂の長側枝 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0006323 ! tassel inflorescence branch
 relationship: develops_from PO:0009104 ! long lateral tassel branch meristem
 
@@ -11947,7 +11883,6 @@ subset: Maize
 synonym: "ramificaci&#243n corta del penacho (borla) (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "third order tassel branch (related)" RELATED []
 synonym: "雄穂短枝 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0006323 ! tassel inflorescence branch
 relationship: develops_from PO:0009103 ! short tassel branch meristem
 
@@ -12020,7 +11955,6 @@ namespace: plant_anatomy
 def: "A reproductive shoot apical meristem that gives rise to the apical growth of the inflorescence. It develops from the shoot apical meristem (SAM) after it undergoes transition from vegetative to reproductive phase." [Gramene:Pankaj_Jaiswal, MaizeGDB_curator:Leszek_Vincent]
 synonym: "meristema apical de la inflorescencia (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "花序頂端分裂組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0000230 ! inflorescence meristem
 is_a: PO:0008028 ! reproductive shoot apical meristem
 relationship: develops_from PO:0008016 ! vegetative shoot apical meristem
@@ -12124,7 +12058,6 @@ comment: Found some taxa, such as Phaseolus.
 synonym: "barra de la traqueida (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "仮導管の筋、縞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:434
-is_a: BFO:0000004
 is_a: PO:0005352 ! xylem
 relationship: adjacent_to PO:0020063 ! hilum
 relationship: part_of PO:0009010 ! seed
@@ -12184,7 +12117,6 @@ synonym: "Zea ovule (narrow)" NARROW []
 synonym: "胚珠 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:464
 xref: PO_GIT:70
-is_a: BFO:0000004
 is_a: PO:0009008 ! plant organ
 relationship: develops_from PO:0000018 ! ovule primordium
 
@@ -12542,7 +12474,6 @@ subset: reference
 synonym: "obturador (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "portion of obturator tissue (exact)" EXACT []
 synonym: "閉塞組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0020006 ! funicle
 
@@ -12615,7 +12546,6 @@ def: "The first stem internode (PO:0020142) above the cotyledonary node (PO:0025
 synonym: "epic&#243tile (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "上胚軸 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:342
-is_a: BFO:0000002
 is_a: PO:0020142 ! stem internode
 relationship: participates_in PO:0007054 ! epicotyl emergence stage
 
@@ -13262,7 +13192,6 @@ comment: The suspensor often allows the embryo to penetrate deep into the endosp
 synonym: "suspensor (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "胚柄 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:248
-is_a: BFO:0000004
 is_a: PO:0025099 ! embryo plant structure
 relationship: develops_from PO:0002002 ! embryo basal cell
 
@@ -13317,7 +13246,7 @@ id: PO:0020122
 name: inflorescence axis
 namespace: plant_anatomy
 def: "A shoot axis (PO:0025029) that is part of an inflorescence (PO:0009049)." [POC:curators]
-comment: An inflorescence axis (PO:0020122) has either a determinate apex, which terminates in a flower meristem (PO:0000229), or has an indeterminate apex, which terminates in an inflorescence apical meristem (PO:0009108).  An inflorescence pedicel (PO:0009052) is the simplest example of a determinate inflorescence axis. {xref="NYBG:Brandon_Sinn", xref="POC:Laurel_Cooper", xref="NYBG:Dario_Cavaliere"}
+comment: An inflorescence axis (PO:0020122) has either a determinate apex, which terminates in a flower meristem (PO:0000229), or has an indeterminate apex, which terminates in an inflorescence apical meristem (PO:0009108).  An inflorescence pedicel (PO:0009052) is the simplest example of a determinate inflorescence axis. {xref="POC:Laurel_Cooper", xref="NYBG:Dario_Cavaliere", xref="NYBG:Brandon_Sinn"}
 subset: Angiosperm
 subset: TraitNet
 synonym: "eje de la inflorescencia (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
@@ -13449,7 +13378,6 @@ def: "Cell that constitutes the central part of the root cap, arranged in longit
 subset: CL
 synonym: "c&#233lula de la columela del caliptra de la ra&#237z (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "柱軸根冠細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025030 ! ground tissue cell
 relationship: develops_from PO:0020133 ! columella root cap initial cell
 
@@ -14041,7 +13969,6 @@ synonym: "root (broad)" BROAD [FNA:b7ce680b-c6ed-4d2e-81e6-66970f7deff9]
 synonym: "sistema de ra&#237z (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "根系 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:136
-is_a: BFO:0000002
 is_a: PO:0025007 ! collective plant organ structure
 relationship: participates_in PO:0028002 ! sporophyte development stage
 created_by: rwalls
@@ -14547,7 +14474,6 @@ synonym: "fundamental tissue (exact)" EXACT [ISBN:0471244554]
 synonym: "porci&#243n del tejido fundamental (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "基本組織の一部 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:106
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0025594 ! ground meristem
 created_by: Laurel_Cooper
@@ -14760,7 +14686,6 @@ subset: Angiosperm
 synonym: "saco embrionario (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "胚嚢 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:130
-is_a: BFO:0000040
 is_a: PO:0025279 ! megagametophyte
 relationship: develops_from PO:0020019 ! megaspore
 relationship: located_in PO:0025490 ! plant ovary ovule
@@ -14877,7 +14802,6 @@ def: "A shoot system (PO:0009006) in the sporophytic phase that has as part at l
 subset: TraitNet
 synonym: "sistema de brote reproductivo (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "生殖シュート 系、苗条系 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000002
 is_a: PO:0009006 ! shoot system
 relationship: participates_in PO:0025530 ! reproductive shoot system development stage
 created_by: rwalls
@@ -14999,7 +14923,6 @@ synonym: "spore case (exact)" EXACT [FNA:808e89e2-7155-41e5-b7b9-a887000d1734]
 synonym: "胞子嚢 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:251
 xref: PO_GIT:257
-is_a: BFO:0000002
 is_a: PO:0009008 ! plant organ
 relationship: participates_in PO:0028002 ! sporophyte development stage
 created_by: rwalls
@@ -15132,7 +15055,7 @@ id: PO:0025104
 name: first order inflorescence axis
 namespace: plant_anatomy
 def: "An inflorescence axis (PO:0020122) that is the primary or main axis of an inflorescence (PO:0009049)." [POC:Ramona_Walls]
-comment: Monopodial inflorescences, such as a raceme inflorescence (PO:0030115), have a centrally-located main axis; this axis is a first order inflorescence axis. In contrast, sympodial inflorescences, such as the riphidium inflorescence (PO:0030131), do not have a centrally-located main axis. The basal-most portion of a first order inflorescence axis is referred to as a peduncle (PO:0009053). {xref="NYBG:Brandon_Sinn", xref="PO:cooperl", xref="NYBG:Dario_Cavaliere"}
+comment: Monopodial inflorescences, such as a raceme inflorescence (PO:0030115), have a centrally-located main axis; this axis is a first order inflorescence axis. In contrast, sympodial inflorescences, such as the riphidium inflorescence (PO:0030131), do not have a centrally-located main axis. The basal-most portion of a first order inflorescence axis is referred to as a peduncle (PO:0009053). {xref="NYBG:Dario_Cavaliere", xref="PO:cooperl", xref="NYBG:Brandon_Sinn"}
 subset: Angiosperm
 synonym: "inflorescence rachis (exact)" EXACT [FNA:78c2e094-f6db-4d95-b8bb-3e2bdaebf764]
 synonym: "inflorescence rhachis (exact)" EXACT [FNA:f76f9272-ef24-4be8-a9b3-3da4c06bd8cf]
@@ -15406,7 +15329,6 @@ synonym: "archegonial egg cell (exact)" EXACT []
 synonym: "ooc&#233lula del arquegonio (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "造卵器卵細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:140
-is_a: BFO:0000040
 is_a: PO:0020094 ! plant egg cell
 relationship: develops_from PO:0025509 ! archegonium central cell
 relationship: located_in PO:0030038 ! venter
@@ -15443,7 +15365,6 @@ synonym: "gametangio (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandol
 synonym: "gametangium (broad)" BROAD []
 synonym: "多細胞植物配偶子嚢  (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:513
-is_a: BFO:0000002
 is_a: PO:0009008 ! plant organ
 relationship: participates_in PO:0028003 ! gametophyte development stage
 created_by: rwalls
@@ -15478,7 +15399,6 @@ synonym: "archegonia (exact, plural)" EXACT []
 synonym: "arquegonio (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "造卵器 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:211
-is_a: BFO:0000004
 is_a: PO:0025124 ! multicellular plant gametangium
 relationship: develops_from PO:0025510 ! archegonium initial cell
 created_by: rwalls
@@ -15511,7 +15431,6 @@ synonym: "portion of phyllome primordium tissue (exact)" EXACT []
 synonym: "primordio del filoma (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "フィロム原基（可視的）  (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:466
-is_a: BFO:0000004
 is_a: PO:0025127 ! primordium
 relationship: develops_from PO:0025430 ! phyllome anlagen
 relationship: part_of PO:0000037 ! shoot axis apex
@@ -15559,6 +15478,7 @@ comment: Includes both material entities such as plant structures and immaterial
 synonym: "entidad anat&#243mica vegetal (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "植物 解剖学（形態）的実体 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:224
+is_a: BFO:0000040
 relationship: only_in_taxon NCBITaxon:33090 {source="cjm"}
 created_by: rwalls
 creation_date: 2010-11-15T11:41:38Z
@@ -16464,7 +16384,6 @@ subset: CL
 synonym: "c&#233lula del tubo pol&#237nico (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "花粉管細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:192
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0020099 ! microgametophyte vegetative cell
 created_by: rwalls
@@ -16886,7 +16805,6 @@ def: "A portion of plant tissue consisting of four megaspores that remained join
 comment: Usually only one of the four megaspores develops and the other three die.
 synonym: "t&#233trada de megasporas (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "大胞子の四分子 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0009007 ! portion of plant tissue
 relationship: develops_from PO:0000431 ! megasporocyte
 relationship: has_part PO:0020019 ! megaspore
@@ -17085,7 +17003,6 @@ namespace: plant_anatomy
 def: "A shoot axis (PO:0025029) that is part of an infructescence (PO:0006342)." [POC:Ramona_Walls]
 synonym: "eje de la infructescencia (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "果序軸 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000004
 is_a: PO:0025029 ! shoot axis
 relationship: develops_from PO:0020122 ! inflorescence axis
 relationship: part_of PO:0006342 ! infructescence
@@ -17362,7 +17279,6 @@ synonym: "ovary septa (exact, plural)" EXACT [FNA:4be9b3cd-7aae-4eee-a102-19a6b4
 synonym: "septo del ovario (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "子房隔壁   (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:277
-is_a: BFO:0000004
 is_a: PO:0000030 ! septum
 relationship: develops_from PO:0005022 ! plant ovary wall
 relationship: part_of PO:0009062 ! gynoecium
@@ -17457,7 +17373,6 @@ synonym: "septo del fruto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_G
 synonym: "果実隔壁 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PlantSystematics_image_archive:1597
 xref: PO_GIT:277
-is_a: BFO:0000004
 is_a: PO:0000030 ! septum
 relationship: develops_from PO:0025262 ! plant ovary septum
 relationship: part_of PO:0009001 ! fruit
@@ -17488,7 +17403,6 @@ comment: If you are annotating to this term, please add an additional annotation
 synonym: "l&#243culo del fruto (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "果実室 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:271
-is_a: BFO:0000004
 is_a: PO:0025263 ! locule
 relationship: develops_from PO:0025266 ! plant ovary locule
 relationship: part_of PO:0009001 ! fruit
@@ -17634,7 +17548,6 @@ synonym: "polen (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "pollen grain (exact)" EXACT []
 synonym: "花粉 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:319
-is_a: BFO:0000040
 is_a: PO:0025280 ! microgametophyte
 relationship: develops_from PO:0020048 ! microspore
 relationship: located_in PO:0025277 ! pollen sac
@@ -17685,7 +17598,6 @@ synonym: "c&#233lula apical del embri&#243n (Spanish, exact)" EXACT Spanish [POC
 synonym: "embryonic meristematic apical cell (exact)" EXACT []
 synonym: "胚頂端細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:281
-is_a: BFO:0000004
 is_a: PO:0025028 ! embryo plant cell
 is_a: PO:0030015 ! sporophyte meristematic apical cell
 relationship: develops_from PO:0000423 ! plant zygote
@@ -17728,7 +17640,6 @@ comment: A seedling coleoptile  develops from an embryo coleoptile (PO:0025286).
 synonym: "cole&#243ptile de la pl&#225ntula (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "実生幼葉鞘 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:294
-is_a: BFO:0000004
 is_a: PO:0020033 ! coleoptile
 relationship: develops_from PO:0025286 ! plant embryo coleoptile
 relationship: participates_in PO:0007131 ! seedling development stage
@@ -17758,7 +17669,6 @@ comment: Develops from an embryo coleorhiza (PO:0025288).
 synonym: "coleorriza de la pl&#225ntula (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "実生根鞘 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:340
-is_a: BFO:0000004
 is_a: PO:0020034 ! coleorhiza
 relationship: develops_from PO:0025288 ! embryo coleorhiza
 created_by: rwalls
@@ -17788,7 +17698,6 @@ comment: Develops from an embryo hypocotyl (PO:0025290). This term should only b
 synonym: "hipoc&#243tile de la pl&#225ntula (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "実生胚軸 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:341
-is_a: BFO:0000004
 is_a: PO:0020100 ! hypocotyl
 relationship: develops_from PO:0025290 ! embryo hypocotyl
 relationship: participates_in PO:0007131 ! seedling development stage
@@ -17818,7 +17727,6 @@ comment: Develops from an embryo epicotyl (PO:0025292).
 synonym: "epic&#243tile de la pl&#225ntula (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "実生上胚軸 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:342
-is_a: BFO:0000004
 is_a: PO:0020035 ! epicotyl
 relationship: develops_from PO:0025292 ! embryo epicotyl
 created_by: rwalls
@@ -17847,7 +17755,6 @@ comment: A seedling mesocotyl is an elongation of an embryo mesocotyl (PO:002529
 synonym: "mesoc&#243tile de la plantual (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "実生中胚軸 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:343
-is_a: BFO:0000004
 is_a: PO:0020037 ! mesocotyl
 relationship: develops_from PO:0025294 ! embryo mesocotyl
 created_by: rwalls
@@ -17943,7 +17850,6 @@ comment: Part of a whole plant (PO:0000003) in the seedling development stage (P
 synonym: "conjunci&#243n del hipoc&#243tile-ra&#237z en la pl&#225ntula (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "実生胚軸-根合流点 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:250
-is_a: BFO:0000004
 is_a: PO:0004724 ! hypocotyl-root junction
 relationship: develops_from PO:0025300 ! embryo hypocotyl-root junction
 created_by: rwalls
@@ -18467,7 +18373,6 @@ comment: Includes flower development stage (PO:0007615), corolla development sta
 synonym: "etapa de desarrollo de una estructura colectiva de la planta (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "集合的植物構造の発生過程 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:391
-is_a: BFO:0000003
 is_a: PO:0009012 ! plant structure development stage
 relationship: has_participant PO:0025007 ! collective plant organ structure
 created_by: rwalls
@@ -18879,7 +18784,6 @@ def: "A plant structure development stage (PO:0009012) that has as primary parti
 synonym: "etapa de desarrollo del tricoma (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "毛発生過程 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:401
-is_a: BFO:0000003
 is_a: PO:0009012 ! plant structure development stage
 relationship: has_participant PO:0000282 ! trichome
 created_by: Laurel_Cooper
@@ -18966,7 +18870,6 @@ synonym: "etapa latente de la semilla (Spanish, exact)" EXACT Spanish [POC:Maria
 synonym: "種子休眠期 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:424
 xref: PO_GIT:568
-is_a: BFO:0000003
 is_a: PO:0001170 ! seed development stage
 relationship: has_part PO:0025377 ! plant embryo dormant stage
 relationship: preceded_by PO:0001040 ! dry seed stage
@@ -19088,7 +18991,6 @@ def: "An intercellular space that is located directly below and contiguous with 
 synonym: "cavidad subestom&#225tica (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "気孔下腔、呼吸腔 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:415
-is_a: BFO:0000004
 is_a: PO:0025379 ! intercellular space
 relationship: adjacent_to PO:0008032 ! stomatal pore
 created_by: Laurel_Cooper
@@ -19174,7 +19076,6 @@ comment: Epicuticular waxes may take a variety of forms, such as plates, ribbons
 synonym: "cera epicuticular (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "エピクチクラワックス (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:416
-is_a: BFO:0000004
 is_a: PO:0025386 ! cuticular wax
 relationship: adjacent_to PO:0025387 ! plant cuticle proper
 created_by: Laurel_Cooper
@@ -19433,7 +19334,6 @@ synonym: "leaf margin blastozone  (exact)" EXACT []
 synonym: "leaf margin meristem (exact)" EXACT []
 synonym: "葉縁分裂組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:412
-is_a: BFO:0000002
 is_a: PO:0025404 ! phyllome marginal meristem
 relationship: part_of PO:0009025 ! vascular leaf
 relationship: part_of PO:0025009 ! leaf lamina margin
@@ -19480,7 +19380,6 @@ comment: Forms as part of primary growth (GO term for primary growth has been re
 synonym: "tejido vascular primario (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "一次維管組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:432
-is_a: BFO:0000004
 is_a: PO:0009015 ! portion of vascular tissue
 relationship: develops_from PO:0025275 ! procambium
 created_by: rwalls
@@ -19495,7 +19394,6 @@ comment: Forms as part of secondary growth (GO:0080117) in vascular plants. Ofte
 synonym: "tejido vascular secundario (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "二次維管組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:432
-is_a: BFO:0000004
 is_a: PO:0009015 ! portion of vascular tissue
 intersection_of: PO:0009015 ! portion of vascular tissue
 intersection_of: develops_from PO:0005598 ! vascular cambium
@@ -19542,7 +19440,6 @@ comment: May be found in the ray system (PO:0025411) and sometimes the axial sys
 synonym: "c&#233lula albuminosa (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "有胚乳細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:442
-is_a: BFO:0000004
 is_a: PO:0000074 ! parenchyma cell
 relationship: adjacent_to PO:0025415 ! sieve cell
 relationship: part_of PO:0005417 ! phloem
@@ -19696,7 +19593,6 @@ def: "A plant structure development stage (PO:0009012) that has as primary parti
 synonym: "etapa de desarrollo de tejido vegetal (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "tissue development stage (broad)" BROAD []
 synonym: "植物細胞発生過程 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
-is_a: BFO:0000003
 is_a: PO:0009012 ! plant structure development stage
 relationship: has_participant PO:0009007 ! portion of plant tissue
 created_by: rwalls
@@ -19777,7 +19673,6 @@ comment: The activity of a leaf plate meristem results in increase in the surfac
 synonym: "meristema en placa de la hoja (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "葉の板状分裂組織 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:413
-is_a: BFO:0000002
 is_a: PO:0025428 ! phyllome plate meristem
 relationship: part_of PO:0009025 ! vascular leaf
 relationship: participates_in PO:0001052 ! vascular leaf expansion stage
@@ -20408,7 +20303,6 @@ namespace: plant_structure_development_stage
 def: "A root development stage (PO:0007520) during which a coleorhiza (PO:0020034) emerges from the seed coat (PO:0009088)." [POC:curators]
 comment: Occurs in Poaceae and some other monocotyledons. May occur simultaneously with coleoptile emergence from the growth medium.  The actual point of emergence from the seed coat (PO:0009088) may not be observed if the seed (PO:0009010) is underneath a growth medium. In a fruit (PO:0009001) with a persistent pericarp (PO:0009084), emergence from the seed coat may not be observed. If the fruit is a caryopsis, the dry pericarp is fused with the seed coat, and emergence from the pericarp is simultaneous with emergence from the seed coat. This terms is used only for seed plants.
 xref: PO_GIT:370
-is_a: BFO:0000003
 is_a: PO:0007520 ! root development stage
 relationship: part_of PO:0007057 ! seed germination stage
 created_by: Laurel_Cooper
@@ -20769,7 +20663,6 @@ def: "A fruit development stage (PO:0001002) that begins with the formation of a
 comment: A fruit formation stage may begin without fertilization or formation of a plant zygote (PO:0000423) in cases of parthenocarpy, apomixis, or other hormone-induced conditions. This stage applies to an individual fruit. For the development stage of a whole plant (PO:0000003), use whole plant fruit formation stage (PO:0007042).
 subset: Maize
 xref: PO_GIT:504
-is_a: BFO:0000003
 is_a: PO:0001002 ! fruit development stage
 relationship: has_participant PO:0009001 ! fruit
 created_by: rwalls
@@ -20863,7 +20756,6 @@ comment: The archegonium central cell divides asymmetrically to form a smaller v
 subset: Gymnosperms
 synonym: "造卵器中央細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:182
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0025510 ! archegonium initial cell
 created_by: rwalls
@@ -21036,7 +20928,6 @@ subset: CL
 synonym: "gametangium (broad)" BROAD []
 synonym: "単細胞植物配偶子嚢 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:513
-is_a: BFO:0000002
 is_a: PO:0025606 ! native plant cell
 relationship: participates_in PO:0028003 ! gametophyte development stage
 created_by: Laurel_Cooper
@@ -21074,7 +20965,6 @@ namespace: plant_anatomy
 def: "A native plant cell (PO:0025606) that develops from the archegonium central cell (PO:0025509), and lies at the base of the archegonium neck (PO:0030039), above the archegonium egg cell (PO:0025122) in the venter (PO:0030038)." [ISBN:0521794331, PMID:17041880, POC:Laurel_Cooper]
 comment: The ventral canal cell is smaller than the archegonium egg cell (PO:0025122), which also develops from the asymmetric division of the archegonium central cell (PO:0025509). It lack a plant-type cell wall (GO:0009505) (ref? ). When the archegonium (PO:0025126) is mature, the ventral canal cell (along with the archegonium neck canal cells; PO:0030065), contributes to the formation of the archegonium neck canal (PO:0030066) by distintegrating and becoming mucilaginous. The canal cells and may produce chemicals to attract the male gamete, the antheridium sperm cells (PO:0025120).
 xref: PO_GIT:514
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0025509 ! archegonium central cell
 relationship: part_of PO:0030038 ! venter
@@ -21190,7 +21080,6 @@ def: "A shoot axis (PO:00025029) that develops in an unusual place." [POC:Laurel
 synonym: "eje adventicio del epiblasto (Spanish, exact) (related)" RELATED []
 synonym: "不定シュート軸 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:527
-is_a: BFO:0000004
 is_a: PO:0025029 ! shoot axis
 relationship: develops_from PO:0000055 ! bud
 created_by: Laurel_Cooper
@@ -21682,7 +21571,6 @@ namespace: plant_structure_development_stage
 def: "A vascular leaf initiation stage (PO:0001051) during which the vascular leaf primordium (PO:0004725) develops an adaxial side (PO:0004726) and an abaxial side (PO:0004725)." [POC:Brian_Atkinson, POC:Laurel_Cooper]
 comment: The vascular leaf primordium adaxial side (PO:0004726) is the side proximal to the axis of the vegetative shoot apical meristem (PO:0020148), while abaxial side (PO:0004725) is the distal side.
 xref: PO_GIT:569
-is_a: BFO:0000003
 is_a: PO:0001051 ! vascular leaf initiation stage
 relationship: preceded_by PO:0001019 ! vascular leaf primordium formation stage
 created_by: brianatkinson
@@ -21705,7 +21593,6 @@ namespace: plant_structure_development_stage
 def: "A vascular leaf development stage (PO:0025570) that begins with the formation of procambium (PO:0025275) and protoderm (PO:0006210) and ends with the formation and differentiation of the leaf epidermis (PO:0006016) and leaf vascular system (PO:0000036) and all the specialized cells of the vascular leaf." [POC:Laurel_Cooper]
 synonym: "vascular leaf morphogenesis stage (exact)" EXACT []
 xref: PO_GIT:572
-is_a: BFO:0000003
 is_a: PO:0025570 ! vascular leaf development stage
 relationship: preceded_by PO:0001051 ! vascular leaf initiation stage
 created_by: Laurel_Cooper
@@ -21850,7 +21737,6 @@ comment: During this stage, the process of floral organ development (GO:0048437)
 synonym: "flower morphogenesis stage  (exact)" EXACT []
 xref: PO_GIT:550
 xref: PO_GIT:604
-is_a: BFO:0000003
 is_a: PO:0025339 ! plant organ development stage
 relationship: part_of PO:0007615 ! flower development stage
 relationship: preceded_by PO:0025588 ! flower meristem transition stage
@@ -22095,7 +21981,6 @@ subset: Tomato
 synonym: "fruit pedicel joint (exact)" EXACT []
 synonym: "pedicel joint (related)" RELATED []
 xref: PO_GIT:590
-is_a: BFO:0000004
 is_a: PO:0000146 ! abscission zone
 relationship: develops_from PO:0025608 ! flower pedicel abscission zone
 relationship: part_of PO:0004536 ! infructescence fruit pedicel
@@ -22120,7 +22005,6 @@ namespace: plant_anatomy
 def: "A shoot system (PO:0009006) that has as parts only vegetative tissues and organs." [POC:Laurel_Cooper]
 xref: PO_GIT:167
 xref: PO_GIT:593
-is_a: BFO:0000004
 is_a: PO:0009006 ! shoot system
 relationship: develops_from PO:0000058 ! vegetative bud
 relationship: has_part PO:0025223 ! vegetative shoot apex
@@ -22610,7 +22494,6 @@ synonym: "phyllid apical cell (exact)" EXACT []
 synonym: "phyllid apical initial (exact)" EXACT []
 synonym: "維管束を持たない葉の分裂組織の頂端細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:303
-is_a: BFO:0000004
 is_a: PO:0030011 ! leaf meristematic apical cell
 is_a: PO:0030019 ! gametophore meristematic apical cell
 relationship: develops_from PO:0030087 ! non-vascular leaf initial cell
@@ -22633,7 +22516,6 @@ synonym: "gametophyte apical initial (exact)" EXACT []
 synonym: "gametophytic meristematic apical cell (exact)" EXACT []
 synonym: "配偶体分裂組織の頂端細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:303
-is_a: BFO:0000002
 is_a: PO:0030007 ! meristematic apical cell
 intersection_of: PO:0030007 ! meristematic apical cell
 intersection_of: participates_in PO:0028003 ! gametophyte development stage
@@ -22656,7 +22538,6 @@ synonym: "sporophyte apical initial (related)" RELATED []
 synonym: "sporophytic meristematic apical cell (exact)" EXACT []
 synonym: "胞子体分裂組織の頂端細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:303
-is_a: BFO:0000002
 is_a: PO:0030007 ! meristematic apical cell
 intersection_of: PO:0030007 ! meristematic apical cell
 intersection_of: participates_in PO:0028002 ! sporophyte development stage
@@ -22709,7 +22590,6 @@ synonym: "gamet&#243foro (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Ga
 synonym: "ramet (broad)" BROAD []
 synonym: "茎葉体, 蘚苔類の配偶体 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:287
-is_a: BFO:0000004
 is_a: PO:0009006 ! shoot system
 relationship: develops_from PO:0030026 ! gametophore bud
 relationship: participates_in PO:0028003 ! gametophyte development stage
@@ -22861,7 +22741,6 @@ synonym: "brown bud (exact)" EXACT []
 synonym: "yema del gamet&#243foro (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "茎葉体芽 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:288
-is_a: BFO:0000004
 is_a: PO:0000058 ! vegetative bud
 relationship: develops_from PO:0030083 ! gametophore bud initial cell
 relationship: participates_in PO:0028003 ! gametophyte development stage
@@ -22881,7 +22760,6 @@ synonym: "talo (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "thalli (exact, plural)" EXACT []
 synonym: "葉状体 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:317
-is_a: BFO:0000002
 is_a: PO:0000003 ! whole plant
 relationship: participates_in PO:0028003 ! gametophyte development stage
 created_by: rwalls
@@ -22915,7 +22793,6 @@ subset: Pteridophytes
 synonym: "pie del esporofito (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "胞子体あし (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:304
-is_a: BFO:0000002
 is_a: PO:0009008 ! plant organ
 relationship: has_part PO:0000078 ! transfer cell
 relationship: participates_in PO:0028002 ! sporophyte development stage
@@ -22968,7 +22845,6 @@ synonym: "seta (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "setae (related)" RELATED Plural []
 synonym: "とげ、剛毛、コケの柄 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:292
-is_a: BFO:0000002
 is_a: PO:0025066 ! stalk
 relationship: participates_in PO:0028002 ! sporophyte development stage
 created_by: rwalls
@@ -22984,7 +22860,6 @@ subset: Bryophytes
 synonym: "anteridi&#243foro (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "雄器床柄 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:320
-is_a: BFO:0000002
 is_a: PO:0025066 ! stalk
 relationship: has_part PO:0030075 ! antheridium head
 relationship: participates_in PO:0028003 ! gametophyte development stage
@@ -23053,7 +22928,6 @@ synonym: "caliptra de la c&#225psula productora de esporas (Spanish, exact)" EXA
 synonym: "spore capsule calyptrae (exact, plural)" EXACT [FNA:50f48ec3-3dcd-4e7f-b065-b68f92ec5636]
 synonym: "コケ類　蘚帽 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:305
-is_a: BFO:0000004
 is_a: PO:0025001 ! cardinal organ part
 relationship: develops_from PO:0025126 ! archegonium
 relationship: participates_in PO:0028003 ! gametophyte development stage
@@ -23410,7 +23284,6 @@ synonym: "braquicito (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandol
 synonym: "brood cell (exact)" EXACT [ISBN:0962073342]
 synonym: "原糸体細胞の細胞壁を厚くした細胞、耐性細胞(brood cell?) (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:330
-is_a: BFO:0000002
 is_a: PO:0025606 ! native plant cell
 relationship: participates_in PO:0028003 ! gametophyte development stage
 created_by: rwalls
@@ -23429,7 +23302,6 @@ synonym: "c&#233lula del tmema (Spanish, exact)" EXACT Spanish [POC:Maria_Alejan
 synonym: "dlichotmema cell (narrow)" NARROW []
 synonym: "tmema細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:331
-is_a: BFO:0000002
 is_a: PO:0025606 ! native plant cell
 relationship: participates_in PO:0028003 ! gametophyte development stage
 created_by: rwalls
@@ -23461,7 +23333,6 @@ subset: Bryophytes
 synonym: "tmema (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 synonym: "tmema (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 xref: PO_GIT:331
-is_a: BFO:0000002
 is_a: PO:0009007 ! portion of plant tissue
 relationship: has_part PO:0030059 ! tmema cell
 relationship: participates_in PO:0028003 ! gametophyte development stage
@@ -23525,7 +23396,6 @@ synonym: "archegonial neck canal cell (exact)" EXACT []
 synonym: "c&#233lula del canal del cuello del arquegonio (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "造卵器頚溝細胞 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:307
-is_a: BFO:0000004
 is_a: PO:0025606 ! native plant cell
 relationship: develops_from PO:0025510 ! archegonium initial cell
 relationship: part_of PO:0030039 ! archegonium neck
@@ -23625,7 +23495,6 @@ comment: Found in bryophytes and pteridophytes growing from the epidermis of a g
 synonym: "rizoide epid&#233rmico (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "表皮仮根 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:347
-is_a: BFO:0000004
 is_a: PO:0030078 ! rhizoid
 relationship: develops_from PO:0030068 ! epidermal rhizoid initial cell
 created_by: rwalls
@@ -23767,7 +23636,6 @@ subset: Bryophytes
 synonym: "rizoide proton&#233mico (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "原糸体仮根 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:347
-is_a: BFO:0000004
 is_a: PO:0030078 ! rhizoid
 relationship: develops_from PO:0030077 ! protonemal side branch rhizoid initial cell
 created_by: rwalls

--- a/subsets/po-basic.obo
+++ b/subsets/po-basic.obo
@@ -13113,7 +13113,7 @@ id: PO:0020122
 name: inflorescence axis
 namespace: plant_anatomy
 def: "A shoot axis (PO:0025029) that is part of an inflorescence (PO:0009049)." [POC:curators]
-comment: An inflorescence axis (PO:0020122) has either a determinate apex, which terminates in a flower meristem (PO:0000229), or has an indeterminate apex, which terminates in an inflorescence apical meristem (PO:0009108).  An inflorescence pedicel (PO:0009052) is the simplest example of a determinate inflorescence axis. {xref="NYBG:Brandon_Sinn", xref="POC:Laurel_Cooper", xref="NYBG:Dario_Cavaliere"}
+comment: An inflorescence axis (PO:0020122) has either a determinate apex, which terminates in a flower meristem (PO:0000229), or has an indeterminate apex, which terminates in an inflorescence apical meristem (PO:0009108).  An inflorescence pedicel (PO:0009052) is the simplest example of a determinate inflorescence axis. {xref="POC:Laurel_Cooper", xref="NYBG:Dario_Cavaliere", xref="NYBG:Brandon_Sinn"}
 subset: Angiosperm
 subset: TraitNet
 synonym: "eje de la inflorescencia (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
@@ -14911,7 +14911,7 @@ id: PO:0025104
 name: first order inflorescence axis
 namespace: plant_anatomy
 def: "An inflorescence axis (PO:0020122) that is the primary or main axis of an inflorescence (PO:0009049)." [POC:Ramona_Walls]
-comment: Monopodial inflorescences, such as a raceme inflorescence (PO:0030115), have a centrally-located main axis; this axis is a first order inflorescence axis. In contrast, sympodial inflorescences, such as the riphidium inflorescence (PO:0030131), do not have a centrally-located main axis. The basal-most portion of a first order inflorescence axis is referred to as a peduncle (PO:0009053). {xref="NYBG:Brandon_Sinn", xref="PO:cooperl", xref="NYBG:Dario_Cavaliere"}
+comment: Monopodial inflorescences, such as a raceme inflorescence (PO:0030115), have a centrally-located main axis; this axis is a first order inflorescence axis. In contrast, sympodial inflorescences, such as the riphidium inflorescence (PO:0030131), do not have a centrally-located main axis. The basal-most portion of a first order inflorescence axis is referred to as a peduncle (PO:0009053). {xref="NYBG:Dario_Cavaliere", xref="PO:cooperl", xref="NYBG:Brandon_Sinn"}
 subset: Angiosperm
 synonym: "inflorescence rachis (exact)" EXACT [FNA:78c2e094-f6db-4d95-b8bb-3e2bdaebf764]
 synonym: "inflorescence rhachis (exact)" EXACT [FNA:f76f9272-ef24-4be8-a9b3-3da4c06bd8cf]


### PR DESCRIPTION
Added `--exclude-tautologies` to rule for building `po.owl`. This removed the `nothing subclass of nothing` tautology from `po.owl`. 

A number of high-level BFO classes were removed after running `make release`.